### PR TITLE
Add maybe_add_phabricator_link to config for sync

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -212,12 +212,14 @@
         - maybe_assign_jira_user
         - maybe_delete_duplicate
         - maybe_update_issue_status
+        - maybe_add_phabricator_link
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
         - maybe_update_issue_status
         - sync_whiteboard_labels
         - sync_keywords_labels
+        - maybe_add_phabricator_link
       comment:
         - create_comment
     status_map:


### PR DESCRIPTION
Added 'maybe_add_phabricator_link' to existing and new states for fxsync.